### PR TITLE
Fix/memory

### DIFF
--- a/include/audio_processing.hpp
+++ b/include/audio_processing.hpp
@@ -7,12 +7,12 @@
 #include "read_wav.hpp"
 
 std::vector<int16_t> convertBytes(const WavFile& wav);
-std::vector<std::vector<double>> sampleToBlock(std::vector<int16_t>& samples);
+std::vector<std::vector<float>> sampleToBlock(std::vector<int16_t>& samples);
 std::vector<std::complex<double>> discreteFourierTransform(
     const std::vector<double>& sample);
-std::vector<std::complex<double>> fastFourierTransform(
-    const std::vector<double>& sample);
+std::vector<std::complex<float>> fastFourierTransform(
+    const std::vector<float>& sample);
 std::vector<float> computeMagnitude(
-    const std::vector<std::complex<double>>& fourierResult);
+    const std::vector<std::complex<float>>& fourierResult);
 
 #endif

--- a/include/audio_processing.hpp
+++ b/include/audio_processing.hpp
@@ -7,7 +7,7 @@
 #include "read_wav.hpp"
 
 std::vector<int16_t> convertBytes(const WavFile& wav);
-std::vector<std::vector<float>> sampleToBlock(std::vector<int16_t>& samples);
+std::vector<float> getBlock(std::vector<int16_t>& samples, size_t currentIndex);
 std::vector<std::complex<double>> discreteFourierTransform(
     const std::vector<double>& sample);
 std::vector<std::complex<float>> fastFourierTransform(

--- a/include/audio_processing.hpp
+++ b/include/audio_processing.hpp
@@ -11,7 +11,7 @@ std::vector<float> getBlock(std::vector<int16_t>& samples, size_t currentIndex);
 std::vector<std::complex<double>> discreteFourierTransform(
     const std::vector<double>& sample);
 std::vector<std::complex<float>> fastFourierTransform(
-    const std::vector<float>& sample);
+    const std::vector<float>& sample, size_t start, size_t step);
 std::vector<float> computeMagnitude(
     const std::vector<std::complex<float>>& fourierResult);
 

--- a/include/audio_processing.hpp
+++ b/include/audio_processing.hpp
@@ -12,7 +12,7 @@ std::vector<std::complex<double>> discreteFourierTransform(
     const std::vector<double>& sample);
 std::vector<std::complex<double>> fastFourierTransform(
     const std::vector<double>& sample);
-std::vector<double> computeMagnitude(
+std::vector<float> computeMagnitude(
     const std::vector<std::complex<double>>& fourierResult);
 
 #endif

--- a/include/visualise_data.hpp
+++ b/include/visualise_data.hpp
@@ -4,6 +4,6 @@
 #include <vector>
 
 void printBars(const std::vector<double>& magnitudes);
-void waveformVisualiser(const std::vector<double>& magnitudes, int windowWidth,
+void waveformVisualiser(const std::vector<float>& magnitudes, int windowWidth,
                         int windowHeight);
 #endif

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -74,6 +74,10 @@ std::vector<std::complex<double>> discreteFourierTransform(
 std::vector<std::complex<float>> fastFourierTransform(
     const std::vector<float>& sample, size_t start, size_t step) {
   auto subproblem = sample.size() / step;
+  if ((subproblem & (subproblem - 1)) != 0) {
+    throw std::runtime_error("Subproblem size is not a power of 2");
+  }
+
   if (subproblem == 1) {
     return {std::complex<float>(sample[start], 0.0F)};
   }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -39,6 +39,10 @@ std::vector<float> getBlock(std::vector<int16_t>& samples,
 
   auto startingOffset = currentIndex * blockSize;
 
+  if (startingOffset + blockSize > samples.size()) {
+    return block;
+  }
+
   for (size_t i = startingOffset; i < startingOffset + blockSize; ++i) {
     block.push_back(static_cast<float>(samples[i]) / absoluteValue);
   }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -97,7 +97,7 @@ std::vector<std::complex<float>> fastFourierTransform(
   std::vector<std::complex<float>> result(subproblem);
   for (size_t i = 0; i < subproblem / 2; ++i) {
     result[i] = evenVar[i] + twiddle[i] * oddVar[i];
-    result[i + subproblem / 2] = evenVar[i] - twiddle[i] * oddVar[i];
+    result[i + (subproblem / 2)] = evenVar[i] - twiddle[i] * oddVar[i];
   }
   return result;
 }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -79,8 +79,8 @@ std::vector<std::complex<float>> fastFourierTransform(
     return {std::complex<float>(sample[start], 0.0F)};
   }
 
-  auto evenVar = fastFourierTransform(sample, start, step);
-  auto oddVar = fastFourierTransform(sample, start + 1, step);
+  auto evenVar = fastFourierTransform(sample, start, step * 2);
+  auto oddVar = fastFourierTransform(sample, start + step, step * 2);
 
   std::vector<std::complex<float>> twiddle;
 

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <cstddef>
-#include <stdexcept>
 
 #include "read_wav.hpp"
 

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -7,6 +7,7 @@
 #include "read_wav.hpp"
 
 constexpr float M_PIF = 3.1415927F;
+const size_t blockSize = 1024;
 
 // Convert bytes into 16 bit numbers
 std::vector<int16_t> convertBytes(const WavFile& wav) {
@@ -30,22 +31,19 @@ std::vector<int16_t> convertBytes(const WavFile& wav) {
 }
 
 // chunk the audio data
-std::vector<std::vector<float>> sampleToBlock(std::vector<int16_t>& samples) {
+std::vector<float> getBlock(std::vector<int16_t>& samples,
+                            size_t currentIndex) {
   const float absoluteValue = 32768.0F;
-  const size_t blockSize = 1024;
-  const size_t numBlocks = samples.size() / blockSize;
-  std::vector<std::vector<float>> buffer;
+  std::vector<float> block;
+  block.reserve(blockSize);
 
-  for (size_t i = 0; i < numBlocks; ++i) {
-    std::vector<float> block;
-    block.reserve(blockSize);
-    for (size_t j = 0; j < blockSize; ++j) {
-      const int16_t sample = samples[(i * blockSize) + j];
-      block.push_back(static_cast<float>(sample) / absoluteValue);
-    }
-    buffer.push_back(std::move(block));
+  auto startingOffset = currentIndex * blockSize;
+
+  for (size_t i = startingOffset; i < startingOffset + blockSize; ++i) {
+    block.push_back(static_cast<float>(samples[i]) / absoluteValue);
   }
-  return buffer;
+
+  return block;
 }
 
 // calculate discrete fourier transform on a single sample

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -125,7 +125,7 @@ std::vector<float> computeMagnitude(
   }
   // magnitude = sqrt(real^2 + imag^2)
   std::vector<float> magnitude;
-  magnitude.reserve(fourierResult.size() / 2);
+  magnitude.reserve(fourierResult.size());
 
   for (const auto& val : fourierResult) {
     magnitude.push_back(static_cast<float>(std::abs(val)));

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -86,18 +86,18 @@ std::vector<std::complex<float>> fastFourierTransform(
 
   // twiddle[i] = cos(-2πi / N) + i·sin(-2πi / N), where N = sampleSizeHalf
   // This is equivalent to: twiddle[i] = exp(-2πi * i / N)
-  for (size_t i = 0; i < sample.size() / step; ++i) {
+  for (size_t i = 0; i < subproblem / 2; ++i) {
     const std::complex<float> contribution(
-        std::cos(-2.0F * M_PIF * (float)i / (float)sample.size()),
-        std::sin(-2.0F * M_PIF * (float)i / (float)sample.size()));
+        std::cos(-2.0F * M_PIF * (float)i / (float)subproblem),
+        std::sin(-2.0F * M_PIF * (float)i / (float)subproblem));
 
     twiddle.push_back(contribution);
   }
 
-  std::vector<std::complex<float>> result(sample.size());
-  for (size_t i = 0; i < sample.size() / step; ++i) {
+  std::vector<std::complex<float>> result(subproblem);
+  for (size_t i = 0; i < subproblem / 2; ++i) {
     result[i] = evenVar[i] + twiddle[i] * oddVar[i];
-    result[i + sample.size() / step] = evenVar[i] - twiddle[i] * oddVar[i];
+    result[i + subproblem / 2] = evenVar[i] - twiddle[i] * oddVar[i];
   }
   return result;
 }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -6,9 +6,7 @@
 
 #include "read_wav.hpp"
 
-#ifndef M_PIF
-#define M_PIF 3.1415927F
-#endif
+constexpr float M_PIF = 3.1415927F;
 
 // Convert bytes into 16 bit numbers
 std::vector<int16_t> convertBytes(const WavFile& wav) {
@@ -32,18 +30,18 @@ std::vector<int16_t> convertBytes(const WavFile& wav) {
 }
 
 // chunk the audio data
-std::vector<std::vector<double>> sampleToBlock(std::vector<int16_t>& samples) {
-  const double absoluteValue = 32768.0;
+std::vector<std::vector<float>> sampleToBlock(std::vector<int16_t>& samples) {
+  const float absoluteValue = 32768.0F;
   const size_t blockSize = 1024;
   const size_t numBlocks = samples.size() / blockSize;
-  std::vector<std::vector<double>> buffer;
+  std::vector<std::vector<float>> buffer;
 
   for (size_t i = 0; i < numBlocks; ++i) {
-    std::vector<double> block;
+    std::vector<float> block;
     block.reserve(blockSize);
     for (size_t j = 0; j < blockSize; ++j) {
       const int16_t sample = samples[(i * blockSize) + j];
-      block.push_back(static_cast<double>(sample) / absoluteValue);
+      block.push_back(static_cast<float>(sample) / absoluteValue);
     }
     buffer.push_back(std::move(block));
   }
@@ -119,7 +117,7 @@ std::vector<std::complex<float>> fastFourierTransform(
 
 // Compute magnitude spectrum from Fourier Transform (DFT or FFT) result
 std::vector<float> computeMagnitude(
-    const std::vector<std::complex<double>>& fourierResult) {
+    const std::vector<std::complex<float>>& fourierResult) {
   if (fourierResult.empty()) {
     return {};
   }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -6,8 +6,8 @@
 
 #include "read_wav.hpp"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
+#ifndef M_PIF
+#define M_PIF 3.1415927F
 #endif
 
 // Convert bytes into 16 bit numbers
@@ -72,44 +72,44 @@ std::vector<std::complex<double>> discreteFourierTransform(
 }
 
 // radix-2 cooley tukey fast fourier transform using 1024 sample
-std::vector<std::complex<double>> fastFourierTransform(
-    const std::vector<double>& sample) {
+std::vector<std::complex<float>> fastFourierTransform(
+    const std::vector<float>& sample) {
   const size_t sampleSize = sample.size();
   const size_t sampleSizeHalf = sampleSize / 2;
   if ((sampleSize & (sampleSize - 1)) != 0U) {
     throw std::runtime_error("Number is not a power of 2");
   }
   if (sampleSize <= 1) {
-    return {std::complex<double>(sample[0], 0.0)};
+    return {std::complex<float>(sample[0], 0.0F)};
   }
 
-  std::vector<double> odd;
-  std::vector<double> even;
+  std::vector<float> odd;
+  std::vector<float> even;
 
   for (size_t i = 0; i < sampleSize; ++i) {
     if ((i % 2) == 0) {
       even.push_back(sample[i]);
     } else {
-      odd.push_back((sample[i]));
+      odd.push_back(sample[i]);
     }
   }
 
   auto evenVar = fastFourierTransform(even);
   auto oddVar = fastFourierTransform(odd);
 
-  std::vector<std::complex<double>> twiddle;
+  std::vector<std::complex<float>> twiddle;
 
   // twiddle[i] = cos(-2πi / N) + i·sin(-2πi / N), where N = sampleSizeHalf
   // This is equivalent to: twiddle[i] = exp(-2πi * i / N)
   for (size_t i = 0; i < sampleSizeHalf; ++i) {
-    const std::complex<double> contribution(
-        std::cos(-2 * M_PI * (double)i / (double)sampleSize),
-        std::sin(-2 * M_PI * (double)i / (double)sampleSize));
+    const std::complex<float> contribution(
+        std::cos(-2.0F * M_PIF * (float)i / (float)sampleSize),
+        std::sin(-2.0F * M_PIF * (float)i / (float)sampleSize));
 
     twiddle.push_back(contribution);
   }
 
-  std::vector<std::complex<double>> result(sampleSize);
+  std::vector<std::complex<float>> result(sampleSize);
   for (size_t i = 0; i < sampleSizeHalf; ++i) {
     result[i] = evenVar[i] + twiddle[i] * oddVar[i];
     result[i + sampleSizeHalf] = evenVar[i] - twiddle[i] * oddVar[i];

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -118,17 +118,17 @@ std::vector<std::complex<double>> fastFourierTransform(
 }
 
 // Compute magnitude spectrum from Fourier Transform (DFT or FFT) result
-std::vector<double> computeMagnitude(
+std::vector<float> computeMagnitude(
     const std::vector<std::complex<double>>& fourierResult) {
   if (fourierResult.empty()) {
     return {};
   }
   // magnitude = sqrt(real^2 + imag^2)
-  std::vector<double> magnitude;
+  std::vector<float> magnitude;
   magnitude.reserve(fourierResult.size());
 
   for (const auto& val : fourierResult) {
-    magnitude.push_back(std::abs(val));
+    magnitude.push_back(static_cast<float>(std::abs(val)));
   }
   return magnitude;
 }

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -22,7 +22,7 @@ std::vector<int16_t> convertBytes(const WavFile& wav) {
       const auto sample = static_cast<int16_t>(
           (static_cast<uint8_t>(byte2) << 8) | static_cast<uint8_t>(byte1));
 
-      samples.push_back(sample);
+      samples.emplace_back(sample);
     }
   }
 

--- a/src/audio_processing.cpp
+++ b/src/audio_processing.cpp
@@ -125,7 +125,7 @@ std::vector<float> computeMagnitude(
   }
   // magnitude = sqrt(real^2 + imag^2)
   std::vector<float> magnitude;
-  magnitude.reserve(fourierResult.size());
+  magnitude.reserve(fourierResult.size() / 2);
 
   for (const auto& val : fourierResult) {
     magnitude.push_back(static_cast<float>(std::abs(val)));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
 
       if (!cachedMagnitudes[currentBlock].has_value()) {
         cachedMagnitudes[currentBlock] =
-            computeMagnitude(fastFourierTransform(block));
+            computeMagnitude(fastFourierTransform(block, 0, 1));
       }
 
       waveformVisualiser(cachedMagnitudes[currentBlock].value(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,16 +57,14 @@ int main(int argc, char* argv[]) {
       BeginDrawing();
       ClearBackground(BLACK);
 
-      if (cachedMagnitudes[currentBlock].has_value()) {
-        waveformVisualiser(cachedMagnitudes[currentBlock].value(),
-                           GetScreenWidth(), GetScreenHeight());
-      } else {
+      if (!cachedMagnitudes[currentBlock].has_value()) {
         cachedMagnitudes[currentBlock] =
             computeMagnitude(fastFourierTransform(blocks[currentBlock]));
-
-        waveformVisualiser(cachedMagnitudes[currentBlock].value(),
-                           GetScreenWidth(), GetScreenHeight());
       }
+
+      waveformVisualiser(cachedMagnitudes[currentBlock].value(),
+                         GetScreenWidth(), GetScreenHeight());
+
       EndDrawing();
       currentBlock = static_cast<size_t>(currentIndex);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
 
     size_t currentBlock = 0;
     float timePlayed = 0.0F;
-    std::vector<std::optional<std::vector<double>>> cachedMagnitudes(
+    std::vector<std::optional<std::vector<float>>> cachedMagnitudes(
         blocks.size());
 
     while (!WindowShouldClose() && currentBlock < cachedMagnitudes.size()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
     SetTargetFPS(targetFps);
     auto samples = convertBytes(wav);
     PlayMusicStream(music);
-    const size_t totalBlocks = (samples.size() / blockSize - 1) / blockSize;
+    const size_t totalBlocks = samples.size() / blockSize;
 
     size_t currentBlock = 0;
     float timePlayed = 0.0F;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
     SetTargetFPS(targetFps);
     auto samples = convertBytes(wav);
     PlayMusicStream(music);
-    size_t totalBlocks = (samples.size() / blockSize - 1) / blockSize;
+    const size_t totalBlocks = (samples.size() / blockSize - 1) / blockSize;
 
     size_t currentBlock = 0;
     float timePlayed = 0.0F;

--- a/src/visualise_data.cpp
+++ b/src/visualise_data.cpp
@@ -84,7 +84,8 @@ void waveformVisualiser(const std::vector<float>& magnitudes, int windowWidth,
   int posX = initialX;
 
   const int numberOfBars =
-      (windowWidth - 2 * initialX) / (barWidth + amountToIncrease);
+      std::min((windowWidth - 2 * initialX) / (barWidth + amountToIncrease),
+               static_cast<int>(scaledValues.size()));
 
   std::vector<float> numOfBars(static_cast<size_t>(numberOfBars));
   for (size_t i = 0; i < numOfBars.size(); ++i) {

--- a/src/visualise_data.cpp
+++ b/src/visualise_data.cpp
@@ -41,7 +41,7 @@ void printBars(const std::vector<double>& magnitudes, int windowHeight) {
 }
 
 // use raylib to visualise the data
-void waveformVisualiser(const std::vector<double>& magnitudes, int windowWidth,
+void waveformVisualiser(const std::vector<float>& magnitudes, int windowWidth,
                         int windowHeight) {
   if (magnitudes.empty()) {
     return;
@@ -51,26 +51,27 @@ void waveformVisualiser(const std::vector<double>& magnitudes, int windowWidth,
   const double maxHeight = windowHeight * 0.8;
 
   // find largest magnitude
-  double largestMagnitude =
+  float largestMagnitude =
       *std::max_element(magnitudes.begin(), magnitudes.end());
   if (largestMagnitude == 0) {
-    largestMagnitude = 1;
+    largestMagnitude = 1.0F;
   }
 
   // smooth and scale the magnitudes
-  std::vector<double> scaledValues;
-  std::deque<double> previousValues;
+  std::vector<float> scaledValues;
+  std::deque<float> previousValues;
   const size_t smoothingWindow = 2;
-  for (const double magnitude : magnitudes) {
+  for (const float magnitude : magnitudes) {
     previousValues.push_back(magnitude);
     if (previousValues.size() > smoothingWindow) {
       previousValues.pop_front();
     }
 
-    const double average =
-        std::accumulate(previousValues.begin(), previousValues.end(), 0.0) /
-        (double)previousValues.size();
-    const double scaled = (average / largestMagnitude) * maxHeight;
+    const float average =
+        std::accumulate(previousValues.begin(), previousValues.end(), 0.0F) /
+        static_cast<float>(previousValues.size());
+    const float scaled =
+        ((average / largestMagnitude) * static_cast<float>(maxHeight));
 
     scaledValues.push_back(scaled);
   }
@@ -85,13 +86,14 @@ void waveformVisualiser(const std::vector<double>& magnitudes, int windowWidth,
   const int numberOfBars =
       (windowWidth - 2 * initialX) / (barWidth + amountToIncrease);
 
-  std::vector<double> numOfBars(static_cast<size_t>(numberOfBars));
+  std::vector<float> numOfBars(static_cast<size_t>(numberOfBars));
   for (size_t i = 0; i < numOfBars.size(); ++i) {
     numOfBars[i] = scaledValues[i];
   }
 
-  for (const double& val : numOfBars) {
-    DrawRectangle(posX, PosY - int(val), barWidth, int(val), WHITE);
+  for (const float& val : numOfBars) {
+    DrawRectangle(posX, PosY - static_cast<int>(val), barWidth,
+                  static_cast<int>(val), WHITE);
     posX += barWidth + amountToIncrease;
   }
 }


### PR DESCRIPTION

* pre-loaded all fft samples before the main loop to improve performance, allowing a slower startup
* added lazy loading with optional vectors to check if data is already cached
* cleaned up lazy loading logic and switched fft data from doubles to floats to reduce memory usage
* used vectors of optional floats to handle fourier bins more efficiently
* experimented with using half the number of fourier bins but reverted because the visual effect was not as good
* added safety checks for bounds and fixed traversal steps through fft data
* optimised fft by reducing duplicate values and using consistent recursion sizes
* fixed operator precedence issues, added const qualifiers, and clamped the number of bars to valid limits
* cleaned up code by removing unnecessary libraries and formatting
* improved vector construction by using emplace_back
* added checks to ensure fft subproblems are powers of two

these changes improve memory usage, correctness, and safety of fft processing

